### PR TITLE
feat: 更新系処理の結果も標準出力に出す

### DIFF
--- a/src/main/java/io/github/simonnozaki/longtimenosee/LongTimeNoSeeRunner.java
+++ b/src/main/java/io/github/simonnozaki/longtimenosee/LongTimeNoSeeRunner.java
@@ -60,7 +60,7 @@ public class LongTimeNoSeeRunner implements ApplicationRunner {
         }
         var content = Optional
                 .ofNullable(option.optionArgs().get("content").getFirst())
-                .orElse("");;
+                .orElse("");
         var input = new CreateUseCaseInput(content);
         var output = useCase.create(input);
         printer.printForTable(output);

--- a/src/main/java/io/github/simonnozaki/longtimenosee/LongTimeNoSeeRunner.java
+++ b/src/main/java/io/github/simonnozaki/longtimenosee/LongTimeNoSeeRunner.java
@@ -13,7 +13,6 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -49,7 +48,7 @@ public class LongTimeNoSeeRunner implements ApplicationRunner {
     private void printById(AppOption option) {
         var id = option.getIdOrThrow();
         var note = useCase.findById(id);
-        printer.printForTable(List.of(note));
+        printer.printForTable(note);
     }
 
     /**
@@ -63,7 +62,8 @@ public class LongTimeNoSeeRunner implements ApplicationRunner {
                 .ofNullable(option.optionArgs().get("content").getFirst())
                 .orElse("");;
         var input = new CreateUseCaseInput(content);
-        useCase.create(input);
+        var output = useCase.create(input);
+        printer.printForTable(output);
     }
 
     /**
@@ -71,7 +71,8 @@ public class LongTimeNoSeeRunner implements ApplicationRunner {
      */
     private void deleteById(AppOption option) {
         var id = option.getIdOrThrow();
-        useCase.deleteById(id);
+        var output = useCase.deleteById(id);
+        printer.printForTable(output);
     }
 
     /**
@@ -83,6 +84,7 @@ public class LongTimeNoSeeRunner implements ApplicationRunner {
                 .findFirst()
                 .orElseThrow(() -> new InvalidArgumentOptionException("Content required when updating a note"));
         var input = new UpdateUseCaseInput(id, content);
-        useCase.updateById(input);
+        var output = useCase.updateById(input);
+        printer.printForTable(output);
     }
 }

--- a/src/main/java/io/github/simonnozaki/longtimenosee/adapter/ConsolePrinter.java
+++ b/src/main/java/io/github/simonnozaki/longtimenosee/adapter/ConsolePrinter.java
@@ -1,6 +1,6 @@
 package io.github.simonnozaki.longtimenosee.adapter;
 
-import io.github.simonnozaki.longtimenosee.domain.note.usecase.FindUseCaseOutput;
+import io.github.simonnozaki.longtimenosee.domain.note.usecase.UseCaseOutput;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -21,14 +21,26 @@ public class ConsolePrinter {
      * | 1|created at format test |2025-04-20T16:54:50.648110 |2025-04-20T16:54:50.648110 |
      * </pre>
      */
-    public void printForTable(List<FindUseCaseOutput> outputs) {
+    public void printForTable(UseCaseOutput output) {
+        printForTable(List.of(output));
+    }
+
+    /**
+     * 表形式に整形して出力する
+     *
+     * <pre>
+     * | #|Content                |Created at                 |Updated at                 |
+     * | 1|created at format test |2025-04-20T16:54:50.648110 |2025-04-20T16:54:50.648110 |
+     * </pre>
+     */
+    public void printForTable(List<UseCaseOutput> outputs) {
         var tableText = formatForTable(outputs);
         System.out.println(tableText);
     }
 
     private record TextLengths(Integer id, Integer content, Integer createdAt, Integer updatedAt) {}
 
-    private String formatForTable(List<FindUseCaseOutput> outputs) {
+    private String formatForTable(List<UseCaseOutput> outputs) {
         var idColumnMaxLength = getMaxLength(outputs, (n) -> n.getId().toString().length());
         var contentColumnMaxLength = getMaxLength(outputs, (n) -> n.getContent().length());
         var createdAtColumnLength = getMaxLength(outputs, (n) -> n.getCreatedAt().length());
@@ -43,7 +55,7 @@ public class ConsolePrinter {
      * 列ごとの最大長を返す
      * TODO マルチバイト文字を等幅フォントできれいにパディングする
      */
-    private Integer getMaxLength(List<FindUseCaseOutput> outputs, Function<FindUseCaseOutput, Integer> transformer) {
+    private Integer getMaxLength(List<UseCaseOutput> outputs, Function<UseCaseOutput, Integer> transformer) {
         var maxLength = outputs.stream()
                 .map(transformer)
                 .max(Comparator.naturalOrder())
@@ -55,14 +67,14 @@ public class ConsolePrinter {
     /**
      * 表の行を文字列として返す
      */
-    private List<String> toTableRows(List<FindUseCaseOutput> outputs, TextLengths lengths) {
+    private List<String> toTableRows(List<UseCaseOutput> outputs, TextLengths lengths) {
         var header = getHeaderRow(lengths);
         List<String> rows = new ArrayList<String>() {
             {
                 add(header);
             }
         };
-        for (FindUseCaseOutput output: outputs) {
+        for (UseCaseOutput output: outputs) {
             var idText =  pad(lengths.id, output.getId().toString(), Alignment.RIGHT);
             var contentText = pad(lengths.content, output.getContent(), Alignment.LEFT);
             var contentCreatedAt = pad(lengths.createdAt, output.getCreatedAt(), Alignment.LEFT);

--- a/src/main/java/io/github/simonnozaki/longtimenosee/domain/note/UseCase.java
+++ b/src/main/java/io/github/simonnozaki/longtimenosee/domain/note/UseCase.java
@@ -2,7 +2,7 @@ package io.github.simonnozaki.longtimenosee.domain.note;
 
 import io.github.simonnozaki.longtimenosee.application.NotFoundRuntimeException;
 import io.github.simonnozaki.longtimenosee.domain.note.usecase.CreateUseCaseInput;
-import io.github.simonnozaki.longtimenosee.domain.note.usecase.FindUseCaseOutput;
+import io.github.simonnozaki.longtimenosee.domain.note.usecase.UseCaseOutput;
 import io.github.simonnozaki.longtimenosee.domain.note.usecase.UpdateUseCaseInput;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,54 +19,59 @@ public class UseCase {
     @Autowired
     private Repository repository;
 
-    public List<FindUseCaseOutput> listAll() {
+    public List<UseCaseOutput> listAll() {
         var notes = repository.findAll();
         final var message = "%d records found:".formatted(notes.size());
         log.info(message);
 
-        return notes.stream().map(this::fromEntityToOutput).toList();
+        return notes.stream().map(this::toOutput).toList();
     }
 
-    public FindUseCaseOutput findById(Long id) throws NotFoundRuntimeException {
+    public UseCaseOutput findById(Long id) throws NotFoundRuntimeException {
         var note = repository
                 .findById(id)
                 .orElseThrow(() -> new NotFoundRuntimeException("Note id %d not found".formatted(id)));
         log.info("Record id: %d found".formatted(id));
 
-        return fromEntityToOutput(note);
+        return toOutput(note);
     }
 
-    public void create(CreateUseCaseInput input) {
+    public UseCaseOutput create(CreateUseCaseInput input) {
         var content = input.getContent();
-        Entity note = Entity.builder()
-                .content(content)
-                .build();
+        Entity note = Entity.builder().content(content).build();
         repository.save(note);
         log.info("Note saved");
+
+        return toOutput(note);
     }
 
-    public void deleteById(Long id) throws NotFoundRuntimeException {
-        if (!repository.existsById(id)) {
+    public UseCaseOutput deleteById(Long id) throws NotFoundRuntimeException {
+        var target = repository.findById(id);
+        if (target.isEmpty()) {
             throw new NotFoundRuntimeException("Note id: %d not found".formatted(id));
         }
         repository.deleteById(id);
         final var message = "Note id: %d deleted".formatted(id);
         log.info(message);
+
+        return toOutput(target.orElseThrow());
     }
 
-    public void updateById(UpdateUseCaseInput input) throws NotFoundRuntimeException {
+    public UseCaseOutput updateById(UpdateUseCaseInput input) throws NotFoundRuntimeException {
         var id = input.getId();
-        var notes = repository
+        var target = repository
                 .findById(id)
                 .orElseThrow(() -> new NotFoundRuntimeException("Note id %d not found".formatted(id)));
-        notes.setContent(input.getContent());
-        repository.save(notes);
+        target.setContent(input.getContent());
+        repository.save(target);
         final var message = "Note id: %d updated".formatted(id);
         log.info(message);
+
+        return toOutput(target);
     }
 
-    private FindUseCaseOutput fromEntityToOutput(Entity note) {
-        return FindUseCaseOutput.builder()
+    private UseCaseOutput toOutput(Entity note) {
+        return UseCaseOutput.builder()
                 .id(note.getId())
                 .content(note.getContent())
                 .createdAt(note.getCreatedAt())

--- a/src/main/java/io/github/simonnozaki/longtimenosee/domain/note/usecase/UseCaseOutput.java
+++ b/src/main/java/io/github/simonnozaki/longtimenosee/domain/note/usecase/UseCaseOutput.java
@@ -6,13 +6,14 @@ import lombok.Builder;
 import lombok.Data;
 
 /**
- * 参照ユースケース出力オブジェクト
- * 極度に責務の分離をしているが、フィールド数が少なければここまでしないで良い
+ * ユースケース出力オブジェクト
+ * 責務の分離を徹底するべく、ドメインの色を薄めたもの。
+ * もし、参照と更新で必要なアウトプットが変わるのであればこれを分解する。
  */
 @Data
 @AllArgsConstructor
 @Builder
-public class FindUseCaseOutput {
+public class UseCaseOutput {
     @Nonnull
     private Long id;
     private String content;

--- a/src/test/java/io/github/simonnozaki/longtimenosee/domain/note/UseCaseTest.java
+++ b/src/test/java/io/github/simonnozaki/longtimenosee/domain/note/UseCaseTest.java
@@ -1,7 +1,7 @@
 package io.github.simonnozaki.longtimenosee.domain.note;
 
 import io.github.simonnozaki.longtimenosee.application.NotFoundRuntimeException;
-import io.github.simonnozaki.longtimenosee.domain.note.usecase.FindUseCaseOutput;
+import io.github.simonnozaki.longtimenosee.domain.note.usecase.UseCaseOutput;
 import io.github.simonnozaki.longtimenosee.domain.note.usecase.UpdateUseCaseInput;
 import io.vavr.collection.Stream;
 import io.vavr.control.Option;
@@ -51,7 +51,7 @@ public class UseCaseTest {
 
             var note1 = Stream.ofAll(notes.stream()).find(output -> output.getId() == 1L);
             var note2 = Stream.ofAll(notes.stream()).find(output -> output.getId() == 2L);
-            Function<Option<FindUseCaseOutput>, Consumer<String>> createNullAndContentChecker = (note) -> (content) -> {
+            Function<Option<UseCaseOutput>, Consumer<String>> createNullAndContentChecker = (note) -> (content) -> {
                 assertNotNull(note.getOrNull());
                 assertThat(note.getOrElseThrow(RuntimeException::new), hasProperty("content", is(content)));
             };
@@ -139,12 +139,7 @@ public class UseCaseTest {
                     new Entity(1L, "Long time no see", "2025-04-25T13:00:00.000", "2025-04-25T13:00:00.000")
             );
             Mockito.when(repository.findById(1L)).thenReturn(mockResult);
-            assertTrue(repository.findById(1L).isPresent());
-            repository.deleteById(1L);
-            assertThrowsExactly(
-                    NotFoundRuntimeException.class,
-                    () -> useCase.deleteById(1L)
-            );
+            assertDoesNotThrow(() -> repository.deleteById(1L));
         }
     }
 }

--- a/src/test/java/io/github/simonnozaki/longtimenosee/domain/note/UseCaseTest.java
+++ b/src/test/java/io/github/simonnozaki/longtimenosee/domain/note/UseCaseTest.java
@@ -139,7 +139,10 @@ public class UseCaseTest {
                     new Entity(1L, "Long time no see", "2025-04-25T13:00:00.000", "2025-04-25T13:00:00.000")
             );
             Mockito.when(repository.findById(1L)).thenReturn(mockResult);
-            assertDoesNotThrow(() -> repository.deleteById(1L));
+            var result = useCase.deleteById(1L);
+
+            Mockito.verify(repository).deleteById(1L);
+            assertEquals("Long time no see", result.getContent());
         }
     }
 }


### PR DESCRIPTION
# 概要

更新系処理が正常終了できたら、更新内容を確認できるよう標準出力にターゲットを表示する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified output types across create, update, delete, and find operations for notes, simplifying the interface and output handling.
  - Renamed output class to a more general name for broader use.
  - Adjusted printing logic to directly display the results of create, update, and delete actions.
- **Tests**
  - Updated tests to reflect the new unified output type and adjusted test logic for deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
